### PR TITLE
Fix & Adding Auto Check / Instant Kill

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.15.1-R0.1-SNAPSHOT</version>
+            <version>1.15.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/uk/antiperson/stackmob/config/MainConfig.java
+++ b/src/main/java/uk/antiperson/stackmob/config/MainConfig.java
@@ -4,6 +4,7 @@ import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import uk.antiperson.stackmob.StackMob;
 import uk.antiperson.stackmob.entity.death.DeathType;
 import uk.antiperson.stackmob.entity.TagMode;
@@ -32,6 +33,10 @@ public class MainConfig extends SpecialConfigFile {
     public Integer[] getStackRadius(EntityType type) {
         return getList(type, "stack.merge-range").asIntList().toArray(new Integer[2]);
     }
+
+    public boolean isAutoCheckEnabled(){ return getBoolean("check-task.enable"); }
+
+    public int getAutoCheckInterval(){ return getInt("check-task.interval"); }
 
     public int getStackInterval() {
         return getInt("stack.interval");
@@ -172,6 +177,12 @@ public class MainConfig extends SpecialConfigFile {
         }
         return isWorldBlacklisted(entity.getType(), entity.getWorld());
     }
+    public boolean isEntityBlacklisted(LivingEntity entity) {
+        if (getList(entity.getType(), "types-blacklist").contains(entity.getType().toString())) {
+            return true;
+        }
+        return isWorldBlacklisted(entity.getType(), entity.getWorld());
+    }
 
     public DeathType getDeathType(LivingEntity dead) {
         for (String key : getDeathSection(dead)) {
@@ -186,6 +197,11 @@ public class MainConfig extends SpecialConfigFile {
             return DeathType.valueOf(key);
         }
         throw new UnsupportedOperationException("Configuration error - unable to determine death type!");
+    }
+    public boolean isInstantDamage(EntityDamageEvent.DamageCause dc)
+    {
+        ConfigList configDamage = this.getList("instant-death-cause");
+        return configDamage.contains(dc.name());
     }
 
     private Collection<String> getDeathSection(LivingEntity dead) {

--- a/src/main/java/uk/antiperson/stackmob/entity/death/KillStepDamage.java
+++ b/src/main/java/uk/antiperson/stackmob/entity/death/KillStepDamage.java
@@ -37,6 +37,7 @@ public class KillStepDamage extends DeathMethod {
                 }
             }, 5);
         }
+        spawned.getEntity().getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(maxHealth);
         spawned.getEntity().setHealth(maxHealth - leftOverDamage);
     }
 }

--- a/src/main/java/uk/antiperson/stackmob/listeners/DeathListener.java
+++ b/src/main/java/uk/antiperson/stackmob/listeners/DeathListener.java
@@ -12,6 +12,7 @@ import uk.antiperson.stackmob.entity.death.DeathType;
 import uk.antiperson.stackmob.entity.Drops;
 import uk.antiperson.stackmob.entity.StackEntity;
 import uk.antiperson.stackmob.entity.death.DeathMethod;
+import uk.antiperson.stackmob.entity.death.KillAll;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
@@ -32,7 +33,11 @@ public class DeathListener implements Listener {
         if (stackEntity.getSize() == 1) {
             return;
         }
-        DeathMethod deathMethod = calculateDeath(stackEntity);
+        DeathMethod deathMethod;
+        if(sm.getMainConfig().isInstantDamage(stackEntity.getEntity().getLastDamageCause().getCause()))
+            deathMethod = new KillAll(sm, stackEntity);
+        else
+            deathMethod = calculateDeath(stackEntity);
         int deathStep = Math.min(stackEntity.getSize(), deathMethod.calculateStep());
         if (deathStep > 0 && deathStep < stackEntity.getSize()) {
             StackEntity spawned = stackEntity.duplicate();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,6 +18,12 @@ stack:
     enabled: true
     amount: 5
 
+check-task:
+  # Enable auto task check all entities on your map for stacking
+  enable: true
+  # Interval between each check in tick (20 Tick = 1 Second)
+  interval: 6000
+
 # Names of worlds where there should be no stacking
 worlds-blacklist: []
 worlds-blacklist-invert: false
@@ -149,6 +155,16 @@ death:
     reason-blacklist-invert: false
     type-blacklist: []
     type-blacklist-invert: false
+# All event instant kill mob stack (Less than default cause many bug in automatic farm)
+instant-death-cause:
+  - BLOCK_EXPLOSION
+  - SUICIDE
+  - FALL
+  - FALLING_BLOCK
+  - CONTACT
+  - LAVA
+  - MAGIC
+  - SUFFOCATION
 
 # Multiply entity drops on entity death.
 drops:


### PR DESCRIPTION
Little update for fixing error when kill Pillager or any entities have more than 20 HP.
Also adding two features : 
 - Auto Check : Every X time check all entities for adding them in Stack because already spawned entities don't be stacked before.
 - Instant Kill : Check some DamageCause for killing all Stack on many farm.