### PR TITLE
Null check

### DIFF
--- a/src/main/java/uk/antiperson/stackmob/tasks/TagTask.java
+++ b/src/main/java/uk/antiperson/stackmob/tasks/TagTask.java
@@ -41,6 +41,9 @@ public class TagTask extends BukkitRunnable {
                     return;
                 }
                 StackEntity stackEntity = sm.getEntityManager().getStackEntity((LivingEntity) entity);
+                if (stackEntity == null) {
+                    return;
+                }
                 int threshold = sm.getMainConfig().getTagThreshold(stackEntity.getEntity().getType());
                 if (stackEntity.getSize() <= threshold) {
                     return;


### PR DESCRIPTION
should fix this error:
```
WARN 21:48:00
[StackMob]: Task #3080 for StackMob v5.3.2 generated an exception
Console 21:48:00
java.lang.NullPointerException: null
at uk.antiperson.stackmob.tasks.TagTask.run(TagTask.java:44) ~[?:?]
at org.bukkit.craftbukkit.v1_16_R2.scheduler.CraftTask.run(CraftTask.java:99) ~[patched_1.16.3.jar:git-Paper-195]
at org.bukkit.craftbukkit.v1_16_R2.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:468) ~[patched_1.16.3.jar:git-Paper-195]
at net.minecraft.server.v1_16_R2.MinecraftServer.b(MinecraftServer.java:1296) ~[patched_1.16.3.jar:git-Paper-195]
at net.minecraft.server.v1_16_R2.DedicatedServer.b(DedicatedServer.java:371) ~[patched_1.16.3.jar:git-Paper-195]
at net.minecraft.server.v1_16_R2.MinecraftServer.a(MinecraftServer.java:1211) ~[patched_1.16.3.jar:git-Paper-195]
at net.minecraft.server.v1_16_R2.MinecraftServer.w(MinecraftServer.java:999) ~[patched_1.16.3.jar:git-Paper-195]
at net.minecraft.server.v1_16_R2.MinecraftServer.lambda$a$0(MinecraftServer.java:177) ~[patched_1.16.3.jar:git-Paper-195]
at java.lang.Thread.run(Thread.java:834) [?:?]
```