### PR TITLE
Fixes merging inconsistency

### DIFF
--- a/src/main/java/uk/antiperson/stackmob/entity/StackEntity.java
+++ b/src/main/java/uk/antiperson/stackmob/entity/StackEntity.java
@@ -239,22 +239,19 @@ public class StackEntity {
      * @return the entity that was removed
      */
     public StackEntity merge(StackEntity toMerge, boolean unregister) {
-        boolean toMergeBigger = toMerge.getSize() > getSize();
-        StackEntity smallest = toMergeBigger ? this : toMerge;
-        StackEntity biggest = toMergeBigger ? toMerge : this;
-        if (EventHelper.callStackMergeEvent(smallest, biggest).isCancelled()) {
+        if (EventHelper.callStackMergeEvent(this, toMerge).isCancelled()) {
             return null;
         }
-        int totalSize = smallest.getSize() + biggest.getSize();
-        int maxSize = getMaxSize();
+        final int totalSize = getSize() + toMerge.getSize();
+        final int maxSize = getMaxSize();
         if (totalSize > maxSize) {
-            smallest.setSize(totalSize - maxSize);
-            biggest.setSize(maxSize);
+            setSize(totalSize - maxSize);
+            toMerge.setSize(maxSize);
             return null;
         }
-        biggest.incrementSize(smallest.getSize());
-        smallest.remove(unregister);
-        return smallest;
+        incrementSize(toMerge.getSize());
+        toMerge.remove(unregister);
+        return toMerge;
     }
 
     public StackEntity splitIfNotEnough(int itemAmount) {

--- a/src/main/java/uk/antiperson/stackmob/entity/StackEntity.java
+++ b/src/main/java/uk/antiperson/stackmob/entity/StackEntity.java
@@ -239,19 +239,22 @@ public class StackEntity {
      * @return the entity that was removed
      */
     public StackEntity merge(StackEntity toMerge, boolean unregister) {
-        if (EventHelper.callStackMergeEvent(this, toMerge).isCancelled()) {
+        boolean toMergeBigger = toMerge.getSize() > getSize();
+        final StackEntity smallest = toMergeBigger ? this : toMerge;
+        final StackEntity biggest = toMergeBigger ? toMerge : this;
+        if (EventHelper.callStackMergeEvent(smallest, biggest).isCancelled()) {
             return null;
         }
-        final int totalSize = getSize() + toMerge.getSize();
+        final int totalSize = smallest.getSize() + biggest.getSize();
         final int maxSize = getMaxSize();
         if (totalSize > maxSize) {
-            setSize(totalSize - maxSize);
-            toMerge.setSize(maxSize);
+            smallest.setSize(totalSize - maxSize);
+            biggest.setSize(maxSize);
             return null;
         }
-        incrementSize(toMerge.getSize());
-        toMerge.remove(unregister);
-        return toMerge;
+        biggest.incrementSize(smallest.getSize());
+        smallest.remove(unregister);
+        return smallest;
     }
 
     public StackEntity splitIfNotEnough(int itemAmount) {

--- a/src/main/java/uk/antiperson/stackmob/tasks/MergeTask.java
+++ b/src/main/java/uk/antiperson/stackmob/tasks/MergeTask.java
@@ -21,7 +21,7 @@ public class MergeTask extends BukkitRunnable {
 
     public void run() {
         HashSet<StackEntity> toRemove = new HashSet<>();
-        for (StackEntity original : sm.getEntityManager().getStackEntities()) {
+        originals: for (StackEntity original : sm.getEntityManager().getStackEntities()) {
             if (original.isWaiting()) {
                 original.incrementWait();
                 continue;
@@ -52,9 +52,12 @@ public class MergeTask extends BukkitRunnable {
                     continue;
                 }
                 if (nearbyStack.getSize() > 1 || original.getSize() > 1) {
-                    StackEntity removed = original.merge(nearbyStack, false);
+                    final StackEntity removed = nearbyStack.merge(original, false);
                     if (removed != null) {
                         toRemove.add(removed);
+                        if (original == removed) {
+                            continue originals;
+                        }
                         break;
                     }
                     continue;
@@ -74,7 +77,9 @@ public class MergeTask extends BukkitRunnable {
                 toRemove.add(match);
             }
             if (size + original.getSize() > original.getMaxSize()) {
-                for (int stackSize : Utilities.split(size, original.getMaxSize())) {
+                final int toCompleteStack = (original.getMaxSize() - original.getSize());
+                original.incrementSize(toCompleteStack);
+                for (int stackSize : Utilities.split(size - toCompleteStack, original.getMaxSize())) {
                     StackEntity stackEntity = original.duplicate();
                     stackEntity.setSize(stackSize);
                 }

--- a/src/main/java/uk/antiperson/stackmob/tasks/MergeTask.java
+++ b/src/main/java/uk/antiperson/stackmob/tasks/MergeTask.java
@@ -52,7 +52,7 @@ public class MergeTask extends BukkitRunnable {
                     continue;
                 }
                 if (nearbyStack.getSize() > 1 || original.getSize() > 1) {
-                    StackEntity removed = nearbyStack.merge(original, false);
+                    StackEntity removed = original.merge(nearbyStack, false);
                     if (removed != null) {
                         toRemove.add(removed);
                         break;
@@ -73,7 +73,7 @@ public class MergeTask extends BukkitRunnable {
                 match.remove(false);
                 toRemove.add(match);
             }
-            if (size >= original.getMaxSize()) {
+            if (size + original.getSize() > original.getMaxSize()) {
                 for (int stackSize : Utilities.split(size, original.getMaxSize())) {
                     StackEntity stackEntity = original.duplicate();
                     stackEntity.setSize(stackSize);


### PR DESCRIPTION
**This pr fixes a huge inconsistency between merge task and merging the greatest. let me explain the issue.**

Merge task firstly merges directly entities (size 1 and size 45 for example). However, assume the original is the one with the size 1, original is the removed entity => not expected, reallt bad. Indeed, if matches collection is not empty, incrementing the original won't have any effect and entities will be lost. Original can't be the removed one, somehow and whatever the conditions. To fix the issue, we can't really change the reference to original because merge task iterates over a collection. Thus, an easy fix that also avoids breakling other things is to always keep the original alive and adapt merge logic. I hope I was understandable, don't hesitate to ask me for more details, it's quite complex and that's why I spent 1 month finding out this weir behaviour with @Hadusch (thanks again).

Nb: To be honest, I have no serious idea why this issue only occured on chunk borders interactions, but the inconsistency is real and the fix works (tested for 24 hours on 3 different servers and setups).

_Fixes https://github.com/Nathat23/StackMob-5/issues/140_