### PR TITLE
Allow stacked villagers to always drop items.

### DIFF
--- a/src/main/java/uk/antiperson/stackmob/listeners/DropListener.java
+++ b/src/main/java/uk/antiperson/stackmob/listeners/DropListener.java
@@ -1,6 +1,7 @@
 package uk.antiperson.stackmob.listeners;
 
 import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -22,7 +23,9 @@ public class DropListener implements Listener {
 
     @EventHandler
     public void onDropListener(EntityDropItemEvent event) {
-        if (event.getItemDrop().getItemStack().getType() != Material.EGG && event.getItemDrop().getItemStack().getType() != Material.SCUTE) {
+        if (event.getEntity() != EntityType.VILLAGER && 
+                event.getItemDrop().getItemStack().getType() != Material.EGG &&
+                event.getItemDrop().getItemStack().getType() != Material.SCUTE) {
             return;
         }
         if (!sm.getEntityManager().isStackedEntity((LivingEntity) event.getEntity())) {


### PR DESCRIPTION
Note: The only time villagers drop items is when a player with Hero of the Village appears.

Source: https://minecraft.fandom.com/wiki/Villager#Drops 

Unfortunately, I don't know if that still holds true for plugins this plugin supports (ex MythicMobs) though - and this is just a guess - I'd assume that it doesn't.