### PR TITLE
Fix PlayerArmorStandListener "leak"

### DIFF
--- a/src/main/java/uk/antiperson/stackmob/listeners/PlayerArmorStandListener.java
+++ b/src/main/java/uk/antiperson/stackmob/listeners/PlayerArmorStandListener.java
@@ -5,7 +5,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 import uk.antiperson.stackmob.StackMob;
 
-@ListenerMetadata(config = "display-name.nearby.use-armorstand")
+@ListenerMetadata(config = "display-name.nearby.armorstand.enabled")
 public class PlayerArmorStandListener implements Listener {
 
     private final StackMob sm;


### PR DESCRIPTION
The path was no longer valid and may have caused issues not cleaning the watchers between sessions.